### PR TITLE
Make mini-batch logic efficient

### DIFF
--- a/sputniPIC-master/include/Particles.h
+++ b/sputniPIC-master/include/Particles.h
@@ -14,7 +14,8 @@
 /** Structs containing the arrays necessary to run h_interp_particle*/
 typedef struct {
     FPpart* x; FPpart* y; FPpart* z;
-    FPpart* u; FPpart* v; FPpart* w; FPinterp* q;
+    FPpart* u; FPpart* v; FPpart* w; 
+    FPinterp* q; // Only for interp2g
 } particles_pointers;
 
 
@@ -33,11 +34,6 @@ typedef struct {
 
 
 /** Structs for mover_PC */
-typedef struct {  // very similar to particles_pointers but excludes FPinterp* q
-    FPpart* x; FPpart* y; FPpart* z;
-    FPpart* u; FPpart* v; FPpart* w;
-} particle_info;
-
 
 typedef struct {
     FPfield* Ex_flat; FPfield* Ey_flat; FPfield* Ez_flat;
@@ -98,7 +94,7 @@ void particle_deallocate(struct particles*);
 /** particle mover */
 // int mover_PC(struct particles*, struct EMfield*, struct grid*, struct parameters*);
 int mover_PC(struct particles*, struct EMfield*, struct grid*, struct parameters*,
-             particle_info, field_pointers, grd_pointers, int, int);
+             particles_pointers, field_pointers, grd_pointers, int, int);
 
 
 /** Interpolation Particle --> Grid: This is for species */

--- a/sputniPIC-master/include/Particles.h
+++ b/sputniPIC-master/include/Particles.h
@@ -99,6 +99,6 @@ int mover_PC(struct particles*, struct EMfield*, struct grid*, struct parameters
 
 /** Interpolation Particle --> Grid: This is for species */
 void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
-    particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize, int rhocSize);
+               particles_pointers, ids_pointers, grd_pointers, int, int);
 
 #endif

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -25,10 +25,18 @@ void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize,
                          grd_pointers* g_p, field_pointers* f_p);
 
 
-void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, 
-                       particles_pointers p_p, field_pointers f_p, grd_pointers g_p, 
-                       int grdSize, int field_size, PICMode mode, 
+void copy_mover_constants_to_GPU(struct EMfield* field, struct grid* grd, 
+                                 field_pointers f_p, grd_pointers g_p,
+                                 int grdSize, int field_size);
+
+
+void copy_mover_arrays(struct particles* part, 
+                       particles_pointers p_p, PICMode mode, 
                        long from=-1, long to=-1, bool verbose=false);
+
+
+void copy_interp_initial_to_GPU(struct interpDensSpecies* ids, ids_pointers i_p,
+                                int grdSize, int rhocSize);
 
 
 void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -36,18 +36,14 @@ void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& b
                 PICMode mode, PICMode direction);
 
 
-
-void allocate_interp_gpu_memory(struct particles* part, int grdSize, particles_pointers* p_p,
-                                ids_pointers* i_p, grd_pointers* g_p);
+void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize, 
+                                particles_pointers* p_p, ids_pointers* i_p, 
+                                grd_pointers* g_p, field_pointers* f_p);
 
 
 void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
                         particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize,
                         int rhocSize, PICMode mode, long from=-1, long to=-1, bool verbose=false);
-
-
-void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size,
-                               field_pointers* f_pointers);
 
 
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particles_pointers p_info,

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -47,7 +47,7 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
 
 
 void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size,
-                               field_pointers* f_pointers, grd_pointers* g_pointers);
+                               field_pointers* f_pointers);
 
 
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particles_pointers p_info,
@@ -56,7 +56,7 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
 
 
 void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p,
-                     field_pointers* f_pointers, grd_pointers* g_pointers);
+                     field_pointers* f_pointers);
 
 
 void create_particle_batch(long batch_size, particles_pointers p_info_batch);

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -46,19 +46,19 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
                         int rhocSize, PICMode mode, long from=-1, long to=-1, bool verbose=false);
 
 
-void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size, particle_info* p_info,
+void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size,
                                field_pointers* f_pointers, grd_pointers* g_pointers);
 
 
-void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particle_info p_info,
+void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particles_pointers p_info,
                        field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size,
                        PICMode mode, long from=-1, long to=-1, bool verbose=false);
 
 
 void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p,
-                     particle_info* p_info, field_pointers* f_pointers, grd_pointers* g_pointers);
+                     field_pointers* f_pointers, grd_pointers* g_pointers);
 
 
-void create_particle_batch(long batch_size, particle_info p_info_batch);
+void create_particle_batch(long batch_size, particles_pointers p_info_batch);
 
 #endif

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -32,29 +32,27 @@ void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
 
 void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& batch_u, FPpart*& batch_v,
                 FPpart*& batch_w, FPpart*& batch_q, FPpart*& part_x, FPpart*& part_y, FPpart*& part_z,
-                FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q,long from, long to,
-                PICMode mode, PICMode direction);
+                FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q,
+                long from, long to, PICMode mode, PICMode direction);
 
 
 void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize, 
-                                particles_pointers* p_p, ids_pointers* i_p, 
-                                grd_pointers* g_p, field_pointers* f_p);
+                         particles_pointers* p_p, ids_pointers* i_p, 
+                         grd_pointers* g_p, field_pointers* f_p);
 
 
 void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
-                        particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize,
-                        int rhocSize, PICMode mode, long from=-1, long to=-1, bool verbose=false);
+                        particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, 
+                        int grdSize, int rhocSize, PICMode mode, 
+                        long from=-1, long to=-1, bool verbose=false);
 
 
-void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particles_pointers p_info,
-                       field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size,
-                       PICMode mode, long from=-1, long to=-1, bool verbose=false);
+void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, 
+                       particles_pointers p_p, field_pointers f_p, grd_pointers g_p, 
+                       int grdSize, int field_size, PICMode mode, 
+                       long from=-1, long to=-1, bool verbose=false);
 
 
-void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p,
-                     field_pointers* f_pointers);
-
-
-void create_particle_batch(long batch_size, particles_pointers p_info_batch);
+void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p, field_pointers* f_p);
 
 #endif

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -25,16 +25,16 @@ void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize,
                          grd_pointers* g_p, field_pointers* f_p);
 
 
-void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
-                        particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, 
-                        int grdSize, int rhocSize, PICMode mode, 
-                        long from=-1, long to=-1, bool verbose=false);
-
-
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, 
                        particles_pointers p_p, field_pointers f_p, grd_pointers g_p, 
                        int grdSize, int field_size, PICMode mode, 
                        long from=-1, long to=-1, bool verbose=false);
+
+
+void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
+                        particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, 
+                        int grdSize, int rhocSize, PICMode mode, 
+                        long from=-1, long to=-1, bool verbose=false);
 
 
 void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p, field_pointers* f_p);

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -20,22 +20,6 @@ enum PICMode
 void print(std::string str);
 
 
-void allocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
-                    FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                    FPpart*& batch_q, long batch_size, PICMode mode);
-
-
-void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
-                      FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                      FPpart*& batch_q, PICMode mode);
-
-
-void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& batch_u, FPpart*& batch_v,
-                FPpart*& batch_w, FPpart*& batch_q, FPpart*& part_x, FPpart*& part_y, FPpart*& part_z,
-                FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q,
-                long from, long to, PICMode mode, PICMode direction);
-
-
 void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize, 
                          particles_pointers* p_p, ids_pointers* i_p, 
                          grd_pointers* g_p, field_pointers* f_p);

--- a/sputniPIC-master/include/helper.h
+++ b/sputniPIC-master/include/helper.h
@@ -6,23 +6,34 @@
 #define MAX_GPU_PARTICLES 14155776  // the number of particles per species in the GEM_3D file is chosen for maximum
 
 
+// Modes for running the functions
+enum PICMode 
+{
+    INTERP2G,
+    MOVER_PC,
+    PARTICLE_TO_BATCH,
+    BATCH_TO_PARTICLE,
+    CPU_TO_GPU,
+    GPU_TO_CPU
+};
+
 void print(std::string str);
 
 
 void allocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
                     FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                    FPpart*& batch_q, long batch_size, std::string mode);
+                    FPpart*& batch_q, long batch_size, PICMode mode);
 
 
 void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
                       FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                      FPpart*& batch_q, std::string mode);
+                      FPpart*& batch_q, PICMode mode);
 
 
 void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& batch_u, FPpart*& batch_v,
                 FPpart*& batch_w, FPpart*& batch_q, FPpart*& part_x, FPpart*& part_y, FPpart*& part_z,
                 FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q,long from, long to,
-                std::string mode, std::string direction);
+                PICMode mode, PICMode direction);
 
 
 
@@ -32,7 +43,7 @@ void allocate_interp_gpu_memory(struct particles* part, int grdSize, particles_p
 
 void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
                         particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize,
-                        int rhocSize, std::string mode, long from=-1, long to=-1, bool verbose=false);
+                        int rhocSize, PICMode mode, long from=-1, long to=-1, bool verbose=false);
 
 
 void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size, particle_info* p_info,
@@ -41,7 +52,7 @@ void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_si
 
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particle_info p_info,
                        field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size,
-                       std::string mode, long from=-1, long to=-1, bool verbose=false);
+                       PICMode mode, long from=-1, long to=-1, bool verbose=false);
 
 
 void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p,

--- a/sputniPIC-master/src/Particles.cu
+++ b/sputniPIC-master/src/Particles.cu
@@ -91,203 +91,15 @@ void particle_deallocate(struct particles* part)
     delete[] part->q;
 }
 
-
-/** CPU serial function to move a single particle during one subcycle. */
-__host__ void h_move_particle(int i, int part_NiterMover, struct grid* grd,
-                              struct parameters* param, const dt_info dt_inf,
-                              particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers) {
-    // extracting the particle variables out of the auxiliary struct
-    FPpart* part_x = p_info.x;
-    FPpart* part_y = p_info.y;
-    FPpart* part_z = p_info.z;
-    FPpart* part_u = p_info.u;
-    FPpart* part_v = p_info.v;
-    FPpart* part_w = p_info.w;
-
-    // extracting the field variables out of the auxiliary struct
-    FPfield* field_Ex_flat = f_pointers.Ex_flat;
-    FPfield* field_Ey_flat = f_pointers.Ey_flat;
-    FPfield* field_Ez_flat = f_pointers.Ez_flat;
-    FPfield* field_Bxn_flat = f_pointers.Bxn_flat;
-    FPfield* field_Byn_flat = f_pointers.Byn_flat;
-    FPfield* field_Bzn_flat = f_pointers.Bzn_flat;
-
-    // extracting the grid variables out of the auxiliary struct
-    FPfield* grd_XN_flat = g_pointers.XN_flat;
-    FPfield* grd_YN_flat = g_pointers.YN_flat;
-    FPfield* grd_ZN_flat = g_pointers.ZN_flat;
-
-    // auxiliary variables
-    FPpart omdtsq, denom, ut, vt, wt, udotb;
-    
-    // local (to the particle) electric and magnetic field
-    FPfield Exl=0.0, Eyl=0.0, Ezl=0.0, Bxl=0.0, Byl=0.0, Bzl=0.0;
-    
-    // interpolation densities
-    int ix,iy,iz;
-    FPfield weight[2][2][2];
-    FPfield xi[2], eta[2], zeta[2];
-    
-    // intermediate particle position and velocity
-    FPpart xptilde, yptilde, zptilde, uptilde, vptilde, wptilde;
-
-    xptilde = part_x[i];
-    yptilde = part_y[i];
-    zptilde = part_z[i];
-    // calculate the average velocity iteratively
-    for(int innter=0; innter < part_NiterMover; innter++){
-        // interpolation G-->P
-        ix = 2 +  int((part_x[i] - grd->xStart)*grd->invdx);
-        iy = 2 +  int((part_y[i] - grd->yStart)*grd->invdy);
-        iz = 2 +  int((part_z[i] - grd->zStart)*grd->invdz);
-        
-        // calculate weights
-        xi[0]   = part_x[i] - grd_XN_flat[get_idx(ix-1, iy, iz, grd->nyn, grd->nzn)];
-        eta[0]  = part_y[i] - grd_YN_flat[get_idx(ix, iy-1, iz, grd->nyn, grd->nzn)];
-        zeta[0] = part_z[i] - grd_ZN_flat[get_idx(ix, iy, iz-1, grd->nyn, grd->nzn)];
-        xi[1]   = grd_XN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_x[i];
-        eta[1]  = grd_YN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_y[i];
-        zeta[1] = grd_ZN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_z[i];
-        for (int ii = 0; ii < 2; ii++)
-            for (int jj = 0; jj < 2; jj++)
-                for (int kk = 0; kk < 2; kk++)
-                    weight[ii][jj][kk] = xi[ii] * eta[jj] * zeta[kk] * grd->invVOL;
-        
-        // set to zero local electric and magnetic field
-        Exl=0.0, Eyl = 0.0, Ezl = 0.0, Bxl = 0.0, Byl = 0.0, Bzl = 0.0;
-        
-        for (int ii=0; ii < 2; ii++)
-            for (int jj=0; jj < 2; jj++)
-                for(int kk=0; kk < 2; kk++){
-                    Exl += weight[ii][jj][kk]*field_Ex_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                    Eyl += weight[ii][jj][kk]*field_Ey_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                    Ezl += weight[ii][jj][kk]*field_Ez_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                    Bxl += weight[ii][jj][kk]*field_Bxn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                    Byl += weight[ii][jj][kk]*field_Byn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                    Bzl += weight[ii][jj][kk]*field_Bzn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
-                }
-        
-        // end interpolation
-        omdtsq = dt_inf.qomdt2*dt_inf.qomdt2*(Bxl*Bxl+Byl*Byl+Bzl*Bzl);
-        denom = 1.0/(1.0 + omdtsq);
-        // solve the position equation
-        ut= part_u[i] + dt_inf.qomdt2*Exl;
-        vt= part_v[i] + dt_inf.qomdt2*Eyl;
-        wt= part_w[i] + dt_inf.qomdt2*Ezl;
-        udotb = ut*Bxl + vt*Byl + wt*Bzl;
-        // solve the velocity equation
-        uptilde = (ut+dt_inf.qomdt2*(vt*Bzl -wt*Byl + dt_inf.qomdt2*udotb*Bxl))*denom;
-        vptilde = (vt+dt_inf.qomdt2*(wt*Bxl -ut*Bzl + dt_inf.qomdt2*udotb*Byl))*denom;
-        wptilde = (wt+dt_inf.qomdt2*(ut*Byl -vt*Bxl + dt_inf.qomdt2*udotb*Bzl))*denom;
-        // update position
-        part_x[i] = xptilde + uptilde*dt_inf.dto2;
-        part_y[i] = yptilde + vptilde*dt_inf.dto2;
-        part_z[i] = zptilde + wptilde*dt_inf.dto2;
-
-
-    } // end of iteration
-    // update the final position and velocity
-    part_u[i] = 2.0 * uptilde - part_u[i];
-    part_v[i] = 2.0 * vptilde - part_v[i];
-    part_w[i] = 2.0 * wptilde - part_w[i];
-    part_x[i] = xptilde + uptilde * dt_inf.dt_sub_cycling;
-    part_y[i] = yptilde + vptilde * dt_inf.dt_sub_cycling;
-    part_z[i] = zptilde + wptilde * dt_inf.dt_sub_cycling;
-
-
-    //////////
-    //////////
-    ////////// BC
-                                
-    // X-DIRECTION: BC particles
-    if (part_x[i] > grd->Lx){
-        if (param->PERIODICX==true){ // PERIODIC
-            part_x[i] = part_x[i] - grd->Lx;
-        } else { // REFLECTING BC
-            part_u[i] = -part_u[i];
-            part_x[i] = 2*grd->Lx - part_x[i];
-        }
-    }
-                                                                
-    if (part_x[i] < 0){
-        if (param->PERIODICX==true){ // PERIODIC
-           part_x[i] = part_x[i] + grd->Lx;
-        } else { // REFLECTING BC
-            part_u[i] = -part_u[i];
-            part_x[i] = -part_x[i];
-        }
-    }
-        
-
-    // Y-DIRECTION: BC particles
-    if (part_y[i] > grd->Ly){
-        if (param->PERIODICY==true){ // PERIODIC
-            part_y[i] = part_y[i] - grd->Ly;
-        } else { // REFLECTING BC
-            part_v[i] = -part_v[i];
-            part_y[i] = 2*grd->Ly - part_y[i];
-        }
-    }
-                                                                
-    if (part_y[i] < 0){
-        if (param->PERIODICY==true){ // PERIODIC
-            part_y[i] = part_y[i] + grd->Ly;
-        } else { // REFLECTING BC
-            part_v[i] = -part_v[i];
-            part_y[i] = -part_y[i];
-        }
-    }
-                                                                
-    // Z-DIRECTION: BC particles
-    if (part_z[i] > grd->Lz){
-        if (param->PERIODICZ==true){ // PERIODIC
-            part_z[i] = part_z[i] - grd->Lz;
-        } else { // REFLECTING BC
-            part_w[i] = -part_w[i];
-            part_z[i] = 2*grd->Lz - part_z[i];
-        }
-    }
-                                                                
-    if (part_z[i] < 0){
-        if (param->PERIODICZ==true){ // PERIODIC
-            part_z[i] = part_z[i] + grd->Lz;
-        } else { // REFLECTING BC
-            part_w[i] = -part_w[i];
-            part_z[i] = -part_z[i];
-        }
-    }
-}
-
-
 /** GPU kernel to move a single particle */
 __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, struct grid grd,
                                 struct parameters param, const dt_info dt_inf,
-                                particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers) {
+                                particles_pointers part, field_pointers field, grd_pointers grd_p) 
+{
     // getting thread ID
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i > nop) return;
 
-    // extracting the particle variables out of the auxiliary struct
-    FPpart* part_x = p_info.x;
-    FPpart* part_y = p_info.y;
-    FPpart* part_z = p_info.z;
-    FPpart* part_u = p_info.u;
-    FPpart* part_v = p_info.v;
-    FPpart* part_w = p_info.w;
-
-    // extracting the field variables out of the auxiliary struct
-    FPfield* field_Ex_flat = f_pointers.Ex_flat;
-    FPfield* field_Ey_flat = f_pointers.Ey_flat;
-    FPfield* field_Ez_flat = f_pointers.Ez_flat;
-    FPfield* field_Bxn_flat = f_pointers.Bxn_flat;
-    FPfield* field_Byn_flat = f_pointers.Byn_flat;
-    FPfield* field_Bzn_flat = f_pointers.Bzn_flat;
-
-    // extracting the grid variables out of the auxiliary struct
-    FPfield* grd_XN_flat = g_pointers.XN_flat;
-    FPfield* grd_YN_flat = g_pointers.YN_flat;
-    FPfield* grd_ZN_flat = g_pointers.ZN_flat;
-
     // auxiliary variables
     FPpart omdtsq, denom, ut, vt, wt, udotb;
 
@@ -302,26 +114,26 @@ __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, 
     // intermediate particle position and velocity
     FPpart xptilde, yptilde, zptilde, uptilde, vptilde, wptilde;
 
-    xptilde = part_x[i];
-    yptilde = part_y[i];
-    zptilde = part_z[i];
+    xptilde = part.x[i];
+    yptilde = part.y[i];
+    zptilde = part.z[i];
 
     // start subcycling
     for (int i_sub=0; i_sub < n_sub_cycles; i_sub++) {
         // calculate the average velocity iteratively
         for (int innter = 0; innter < part_NiterMover; innter++) {
             // interpolation G-->P
-            ix = 2 + int((part_x[i] - grd.xStart) * grd.invdx);
-            iy = 2 + int((part_y[i] - grd.yStart) * grd.invdy);
-            iz = 2 + int((part_z[i] - grd.zStart) * grd.invdz);
+            ix = 2 + int((part.x[i] - grd.xStart) * grd.invdx);
+            iy = 2 + int((part.y[i] - grd.yStart) * grd.invdy);
+            iz = 2 + int((part.z[i] - grd.zStart) * grd.invdz);
 
             // calculate weights
-            xi[0] = part_x[i] - grd_XN_flat[get_idx(ix - 1, iy, iz, grd.nyn, grd.nzn)];
-            eta[0] = part_y[i] - grd_YN_flat[get_idx(ix, iy - 1, iz, grd.nyn, grd.nzn)];
-            zeta[0] = part_z[i] - grd_ZN_flat[get_idx(ix, iy, iz - 1, grd.nyn, grd.nzn)];
-            xi[1] = grd_XN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part_x[i];
-            eta[1] = grd_YN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part_y[i];
-            zeta[1] = grd_ZN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part_z[i];
+            xi[0] = part.x[i] - grd_p.XN_flat[get_idx(ix - 1, iy, iz, grd.nyn, grd.nzn)];
+            eta[0] = part.y[i] - grd_p.YN_flat[get_idx(ix, iy - 1, iz, grd.nyn, grd.nzn)];
+            zeta[0] = part.z[i] - grd_p.ZN_flat[get_idx(ix, iy, iz - 1, grd.nyn, grd.nzn)];
+            xi[1] = grd_p.XN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.x[i];
+            eta[1] = grd_p.YN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.y[i];
+            zeta[1] = grd_p.ZN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.z[i];
             for (int ii = 0; ii < 2; ii++)
                 for (int jj = 0; jj < 2; jj++)
                     for (int kk = 0; kk < 2; kk++)
@@ -333,43 +145,43 @@ __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, 
             for (int ii = 0; ii < 2; ii++)
                 for (int jj = 0; jj < 2; jj++)
                     for (int kk = 0; kk < 2; kk++) {
-                        Exl += weight[ii][jj][kk] * field_Ex_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
-                        Eyl += weight[ii][jj][kk] * field_Ey_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
-                        Ezl += weight[ii][jj][kk] * field_Ez_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                        Exl += weight[ii][jj][kk] * field.Ex_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                        Eyl += weight[ii][jj][kk] * field.Ey_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                        Ezl += weight[ii][jj][kk] * field.Ez_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
                         Bxl += weight[ii][jj][kk] *
-                               field_Bxn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                               field.Bxn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
                         Byl += weight[ii][jj][kk] *
-                               field_Byn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                               field.Byn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
                         Bzl += weight[ii][jj][kk] *
-                               field_Bzn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
+                               field.Bzn_flat[get_idx(ix - ii, iy - jj, iz - kk, grd.nyn, grd.nzn)];
                     }
 
             // end interpolation
             omdtsq = dt_inf.qomdt2 * dt_inf.qomdt2 * (Bxl * Bxl + Byl * Byl + Bzl * Bzl);
             denom = 1.0 / (1.0 + omdtsq);
             // solve the position equation
-            ut = part_u[i] + dt_inf.qomdt2 * Exl;
-            vt = part_v[i] + dt_inf.qomdt2 * Eyl;
-            wt = part_w[i] + dt_inf.qomdt2 * Ezl;
+            ut = part.u[i] + dt_inf.qomdt2 * Exl;
+            vt = part.v[i] + dt_inf.qomdt2 * Eyl;
+            wt = part.w[i] + dt_inf.qomdt2 * Ezl;
             udotb = ut * Bxl + vt * Byl + wt * Bzl;
             // solve the velocity equation
             uptilde = (ut + dt_inf.qomdt2 * (vt * Bzl - wt * Byl + dt_inf.qomdt2 * udotb * Bxl)) * denom;
             vptilde = (vt + dt_inf.qomdt2 * (wt * Bxl - ut * Bzl + dt_inf.qomdt2 * udotb * Byl)) * denom;
             wptilde = (wt + dt_inf.qomdt2 * (ut * Byl - vt * Bxl + dt_inf.qomdt2 * udotb * Bzl)) * denom;
             // update position
-            part_x[i] = xptilde + uptilde * dt_inf.dto2;
-            part_y[i] = yptilde + vptilde * dt_inf.dto2;
-            part_z[i] = zptilde + wptilde * dt_inf.dto2;
+            part.x[i] = xptilde + uptilde * dt_inf.dto2;
+            part.y[i] = yptilde + vptilde * dt_inf.dto2;
+            part.z[i] = zptilde + wptilde * dt_inf.dto2;
 
 
         } // end of iteration
         // update the final position and velocity
-        part_u[i] = 2.0 * uptilde - part_u[i];
-        part_v[i] = 2.0 * vptilde - part_v[i];
-        part_w[i] = 2.0 * wptilde - part_w[i];
-        part_x[i] = xptilde + uptilde * dt_inf.dt_sub_cycling;
-        part_y[i] = yptilde + vptilde * dt_inf.dt_sub_cycling;
-        part_z[i] = zptilde + wptilde * dt_inf.dt_sub_cycling;
+        part.u[i] = 2.0 * uptilde - part.u[i];
+        part.v[i] = 2.0 * vptilde - part.v[i];
+        part.w[i] = 2.0 * wptilde - part.w[i];
+        part.x[i] = xptilde + uptilde * dt_inf.dt_sub_cycling;
+        part.y[i] = yptilde + vptilde * dt_inf.dt_sub_cycling;
+        part.z[i] = zptilde + wptilde * dt_inf.dt_sub_cycling;
 
 
         //////////
@@ -377,60 +189,60 @@ __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, 
         ////////// BC
 
         // X-DIRECTION: BC particles
-        if (part_x[i] > grd.Lx) {
+        if (part.x[i] > grd.Lx) {
             if (param.PERIODICX == true) { // PERIODIC
-                part_x[i] = part_x[i] - grd.Lx;
+                part.x[i] = part.x[i] - grd.Lx;
             } else { // REFLECTING BC
-                part_u[i] = -part_u[i];
-                part_x[i] = 2 * grd.Lx - part_x[i];
+                part.u[i] = -part.u[i];
+                part.x[i] = 2 * grd.Lx - part.x[i];
             }
         }
 
-        if (part_x[i] < 0) {
+        if (part.x[i] < 0) {
             if (param.PERIODICX == true) { // PERIODIC
-                part_x[i] = part_x[i] + grd.Lx;
+                part.x[i] = part.x[i] + grd.Lx;
             } else { // REFLECTING BC
-                part_u[i] = -part_u[i];
-                part_x[i] = -part_x[i];
+                part.u[i] = -part.u[i];
+                part.x[i] = -part.x[i];
             }
         }
 
 
         // Y-DIRECTION: BC particles
-        if (part_y[i] > grd.Ly) {
+        if (part.y[i] > grd.Ly) {
             if (param.PERIODICY == true) { // PERIODIC
-                part_y[i] = part_y[i] - grd.Ly;
+                part.y[i] = part.y[i] - grd.Ly;
             } else { // REFLECTING BC
-                part_v[i] = -part_v[i];
-                part_y[i] = 2 * grd.Ly - part_y[i];
+                part.v[i] = -part.v[i];
+                part.y[i] = 2 * grd.Ly - part.y[i];
             }
         }
 
-        if (part_y[i] < 0) {
+        if (part.y[i] < 0) {
             if (param.PERIODICY == true) { // PERIODIC
-                part_y[i] = part_y[i] + grd.Ly;
+                part.y[i] = part.y[i] + grd.Ly;
             } else { // REFLECTING BC
-                part_v[i] = -part_v[i];
-                part_y[i] = -part_y[i];
+                part.v[i] = -part.v[i];
+                part.y[i] = -part.y[i];
             }
         }
 
         // Z-DIRECTION: BC particles
-        if (part_z[i] > grd.Lz) {
+        if (part.z[i] > grd.Lz) {
             if (param.PERIODICZ == true) { // PERIODIC
-                part_z[i] = part_z[i] - grd.Lz;
+                part.z[i] = part.z[i] - grd.Lz;
             } else { // REFLECTING BC
-                part_w[i] = -part_w[i];
-                part_z[i] = 2 * grd.Lz - part_z[i];
+                part.w[i] = -part.w[i];
+                part.z[i] = 2 * grd.Lz - part.z[i];
             }
         }
 
-        if (part_z[i] < 0) {
+        if (part.z[i] < 0) {
             if (param.PERIODICZ == true) { // PERIODIC
-                part_z[i] = part_z[i] + grd.Lz;
+                part.z[i] = part.z[i] + grd.Lz;
             } else { // REFLECTING BC
-                part_w[i] = -part_w[i];
-                part_z[i] = -part_z[i];
+                part.w[i] = -part.w[i];
+                part.z[i] = -part.z[i];
             }
         }
     }
@@ -440,7 +252,8 @@ __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, 
 
 /** particle mover */
 int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, struct parameters* param,
-             particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size) {
+             particles_pointers p_p, field_pointers f_p, grd_pointers g_p, int grdSize, int field_size) 
+{
     // print species and subcycling
     std::cout << std::endl << "***  In [mover_PC]: MOVER with SUBCYCLYING "<< param->n_sub_cycles
               << " - species " << part->species_ID << " ***" << std::endl;
@@ -463,14 +276,14 @@ int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, st
                       << " - batch_start: " << batch_start << ", batch_end: " << batch_end
                       << ", batch_size: " << batch_size << std::endl; */
 
-            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, CPU_TO_GPU,
+            copy_mover_arrays(part, field, grd, p_p, f_p, g_p, grdSize, field_size, CPU_TO_GPU,
                               batch_start, batch_end);
 
             g_move_particle<<<(batch_size+TPB-1)/TPB, TPB>>>(batch_size, part->n_sub_cycles, part->NiterMover, *grd,
-                                                                  *param, dt_inf, p_info, f_pointers, g_pointers);
+                                                                  *param, dt_inf, p_p, f_p, g_p);
             cudaDeviceSynchronize();
 
-            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, GPU_TO_CPU,
+            copy_mover_arrays(part, field, grd, p_p, f_p, g_p, grdSize, field_size, GPU_TO_CPU,
                               batch_start, batch_end);
 
             std::cout << "====== In [mover_PC]: batch " << (iter + 1) << " of " << n_iterations << ": done." << std::endl;
@@ -479,175 +292,23 @@ int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, st
 
     // all the particles at once
     else {
-        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, CPU_TO_GPU);
+        copy_mover_arrays(part, field, grd, p_p, f_p, g_p, grdSize, field_size, CPU_TO_GPU);
 
-        // h_move_particle(i, part->NiterMover, grd, param, dt_inf, p_info, f_pointers, g_pointers)
+        // h_move_particle(i, part->NiterMover, grd, param, dt_inf, p_p, f_p, g_p)
         // Launch the kernel
         g_move_particle<<<(part->nop+TPB-1)/TPB, TPB>>>(part->nop, part->n_sub_cycles, part->NiterMover, *grd,
-                *param, dt_inf, p_info, f_pointers, g_pointers);
+                *param, dt_inf, p_p, f_p, g_p);
         cudaDeviceSynchronize();
 
-        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, GPU_TO_CPU);
+        copy_mover_arrays(part, field, grd, p_p, f_p, g_p, grdSize, field_size, GPU_TO_CPU);
     }
     return(0); // exit successfully
 }
 
 
-/** CPU serial function to interpolate for a single particle during one subcycle. */
-__host__ void h_interp_particle(register long long i, struct grid grd,
-    particles_pointers part, ids_pointers ids, grd_pointers grd_p)
-{
-    // arrays needed for interpolation
-    FPpart weight[2][2][2];
-    FPpart temp[2][2][2];
-    FPpart xi[2], eta[2], zeta[2];
-    
-    // index of the cell
-    int ix, iy, iz;
-
-    // determine cell: can we change to int()? is it faster?
-    ix = 2 + int (floor((part.x[i] - grd.xStart) * grd.invdx));
-    iy = 2 + int (floor((part.y[i] - grd.yStart) * grd.invdy));
-    iz = 2 + int (floor((part.z[i] - grd.zStart) * grd.invdz));
-
-    // distances from node
-    xi[0]   = part.x[i] - grd_p.XN_flat[get_idx(ix-1, iy, iz, grd.nyn, grd.nzn)];
-    eta[0]  = part.y[i] - grd_p.YN_flat[get_idx(ix, iy-1, iz, grd.nyn, grd.nzn)];
-    zeta[0] = part.z[i] - grd_p.ZN_flat[get_idx(ix, iy, iz-1, grd.nyn, grd.nzn)];
-    xi[1]   = grd_p.XN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.x[i];
-    eta[1]  = grd_p.YN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.y[i];
-    zeta[1] = grd_p.ZN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.z[i];
-
-    // calculate the weights for different nodes
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                weight[ii][jj][kk] = part.q[i] * xi[ii] * eta[jj] * zeta[kk] * grd.invVOL;
-
-    //////////////////////////
-    // add charge density
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.rhon_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    ////////////////////////////
-    // add current density - Jx
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.u[i] * weight[ii][jj][kk];
-
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.Jx_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    ////////////////////////////
-    // add current density - Jy
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.v[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.Jy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-
-    ////////////////////////////
-    // add current density - Jz
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.w[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.Jz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    ////////////////////////////
-    // add pressure pxx
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.u[i] * part.u[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pxx_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    ////////////////////////////
-    // add pressure pxy
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.u[i] * part.v[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pxy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-
-    /////////////////////////////
-    // add pressure pxz
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.u[i] * part.w[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pxz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    /////////////////////////////
-    // add pressure pyy
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.v[i] * part.v[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pyy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    /////////////////////////////
-    // add pressure pyz
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.v[i] * part.w[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pyz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-
-    /////////////////////////////
-    // add pressure pzz
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                temp[ii][jj][kk] = part.w[i] * part.w[i] * weight[ii][jj][kk];
-    for (int ii = 0; ii < 2; ii++)
-        for (int jj = 0; jj < 2; jj++)
-            for (int kk = 0; kk < 2; kk++)
-                ids.pzz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
-
-}
-
-
 /** GPU kernel to interpolate for a single particle during one subcycle. */
 __global__ void g_interp_particle(int nop, struct grid grd,
-    particles_pointers part, ids_pointers ids, grd_pointers grd_p)
+                                  particles_pointers part, ids_pointers ids, grd_pointers grd_p)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i > nop) return;
@@ -799,33 +460,8 @@ __global__ void g_interp_particle(int nop, struct grid grd,
     }
 }
 
-
-/** Interpolation Particle --> Grid: This is for species */
-// CPU Version
-void h_interpP2G(struct particles* part, struct interpDensSpecies* ids, struct grid* grd)
-{
-    // Create argument structs
-    particles_pointers p_p {
-        part->x, part->y, part->z,
-        part->u, part->v, part->w, part->q
-    };
-    ids_pointers i_p {
-        ids->rhon_flat, ids->rhoc_flat,
-        ids->Jx_flat, ids->Jy_flat, ids->Jz_flat,
-        ids->pxx_flat, ids->pxy_flat, ids->pxz_flat,
-        ids->pyy_flat, ids->pyz_flat, ids->pzz_flat
-    };
-    grd_pointers g_p {
-        grd->XN_flat, grd->YN_flat, grd->ZN_flat
-    };
-    for (register long long i = 0; i < part->nop; i++) {
-        h_interp_particle(i, *grd, p_p, i_p, g_p);
-    }
-}
-
-
 void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
-    particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize, int rhocSize)
+               particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, int grdSize, int rhocSize)
 {
 
     // mini-batches
@@ -869,3 +505,351 @@ void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct gri
         copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, GPU_TO_CPU);
     }
 }
+
+
+
+/* -------------------- *
+ * CPU Serial Versions  *
+ * -------------------- */
+
+/** CPU serial function to move a single particle during one subcycle. */
+__host__ void h_move_particle(int i, int part_NiterMover, struct grid* grd,
+                              struct parameters* param, const dt_info dt_inf,
+                              particles_pointers part, field_pointers field, grd_pointers grd_p) 
+{
+    // extracting the particle variables out of the auxiliary struct
+    FPpart* part_x = part.x;
+    FPpart* part_y = part.y;
+    FPpart* part_z = part.z;
+    FPpart* part_u = part.u;
+    FPpart* part_v = part.v;
+    FPpart* part_w = part.w;
+
+    // extracting the field variables out of the auxiliary struct
+    FPfield* field_Ex_flat = field.Ex_flat;
+    FPfield* field_Ey_flat = field.Ey_flat;
+    FPfield* field_Ez_flat = field.Ez_flat;
+    FPfield* field_Bxn_flat = field.Bxn_flat;
+    FPfield* field_Byn_flat = field.Byn_flat;
+    FPfield* field_Bzn_flat = field.Bzn_flat;
+
+    // extracting the grid variables out of the auxiliary struct
+    FPfield* grd_XN_flat = grd_p.XN_flat;
+    FPfield* grd_YN_flat = grd_p.YN_flat;
+    FPfield* grd_ZN_flat = grd_p.ZN_flat;
+
+    // auxiliary variables
+    FPpart omdtsq, denom, ut, vt, wt, udotb;
+    
+    // local (to the particle) electric and magnetic field
+    FPfield Exl=0.0, Eyl=0.0, Ezl=0.0, Bxl=0.0, Byl=0.0, Bzl=0.0;
+    
+    // interpolation densities
+    int ix,iy,iz;
+    FPfield weight[2][2][2];
+    FPfield xi[2], eta[2], zeta[2];
+    
+    // intermediate particle position and velocity
+    FPpart xptilde, yptilde, zptilde, uptilde, vptilde, wptilde;
+
+    xptilde = part_x[i];
+    yptilde = part_y[i];
+    zptilde = part_z[i];
+    // calculate the average velocity iteratively
+    for(int innter=0; innter < part_NiterMover; innter++){
+        // interpolation G-->P
+        ix = 2 +  int((part_x[i] - grd->xStart)*grd->invdx);
+        iy = 2 +  int((part_y[i] - grd->yStart)*grd->invdy);
+        iz = 2 +  int((part_z[i] - grd->zStart)*grd->invdz);
+        
+        // calculate weights
+        xi[0]   = part_x[i] - grd_XN_flat[get_idx(ix-1, iy, iz, grd->nyn, grd->nzn)];
+        eta[0]  = part_y[i] - grd_YN_flat[get_idx(ix, iy-1, iz, grd->nyn, grd->nzn)];
+        zeta[0] = part_z[i] - grd_ZN_flat[get_idx(ix, iy, iz-1, grd->nyn, grd->nzn)];
+        xi[1]   = grd_XN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_x[i];
+        eta[1]  = grd_YN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_y[i];
+        zeta[1] = grd_ZN_flat[get_idx(ix, iy, iz, grd->nyn, grd->nzn)] - part_z[i];
+        for (int ii = 0; ii < 2; ii++)
+            for (int jj = 0; jj < 2; jj++)
+                for (int kk = 0; kk < 2; kk++)
+                    weight[ii][jj][kk] = xi[ii] * eta[jj] * zeta[kk] * grd->invVOL;
+        
+        // set to zero local electric and magnetic field
+        Exl=0.0, Eyl = 0.0, Ezl = 0.0, Bxl = 0.0, Byl = 0.0, Bzl = 0.0;
+        
+        for (int ii=0; ii < 2; ii++)
+            for (int jj=0; jj < 2; jj++)
+                for(int kk=0; kk < 2; kk++){
+                    Exl += weight[ii][jj][kk]*field_Ex_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                    Eyl += weight[ii][jj][kk]*field_Ey_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                    Ezl += weight[ii][jj][kk]*field_Ez_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                    Bxl += weight[ii][jj][kk]*field_Bxn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                    Byl += weight[ii][jj][kk]*field_Byn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                    Bzl += weight[ii][jj][kk]*field_Bzn_flat[get_idx(ix-ii, iy-jj, iz-kk, grd->nyn, grd->nzn)];
+                }
+        
+        // end interpolation
+        omdtsq = dt_inf.qomdt2*dt_inf.qomdt2*(Bxl*Bxl+Byl*Byl+Bzl*Bzl);
+        denom = 1.0/(1.0 + omdtsq);
+        // solve the position equation
+        ut= part_u[i] + dt_inf.qomdt2*Exl;
+        vt= part_v[i] + dt_inf.qomdt2*Eyl;
+        wt= part_w[i] + dt_inf.qomdt2*Ezl;
+        udotb = ut*Bxl + vt*Byl + wt*Bzl;
+        // solve the velocity equation
+        uptilde = (ut+dt_inf.qomdt2*(vt*Bzl -wt*Byl + dt_inf.qomdt2*udotb*Bxl))*denom;
+        vptilde = (vt+dt_inf.qomdt2*(wt*Bxl -ut*Bzl + dt_inf.qomdt2*udotb*Byl))*denom;
+        wptilde = (wt+dt_inf.qomdt2*(ut*Byl -vt*Bxl + dt_inf.qomdt2*udotb*Bzl))*denom;
+        // update position
+        part_x[i] = xptilde + uptilde*dt_inf.dto2;
+        part_y[i] = yptilde + vptilde*dt_inf.dto2;
+        part_z[i] = zptilde + wptilde*dt_inf.dto2;
+
+
+    } // end of iteration
+    // update the final position and velocity
+    part_u[i] = 2.0 * uptilde - part_u[i];
+    part_v[i] = 2.0 * vptilde - part_v[i];
+    part_w[i] = 2.0 * wptilde - part_w[i];
+    part_x[i] = xptilde + uptilde * dt_inf.dt_sub_cycling;
+    part_y[i] = yptilde + vptilde * dt_inf.dt_sub_cycling;
+    part_z[i] = zptilde + wptilde * dt_inf.dt_sub_cycling;
+
+
+    //////////
+    //////////
+    ////////// BC
+                                
+    // X-DIRECTION: BC particles
+    if (part_x[i] > grd->Lx){
+        if (param->PERIODICX==true){ // PERIODIC
+            part_x[i] = part_x[i] - grd->Lx;
+        } else { // REFLECTING BC
+            part_u[i] = -part_u[i];
+            part_x[i] = 2*grd->Lx - part_x[i];
+        }
+    }
+                                                                
+    if (part_x[i] < 0){
+        if (param->PERIODICX==true){ // PERIODIC
+           part_x[i] = part_x[i] + grd->Lx;
+        } else { // REFLECTING BC
+            part_u[i] = -part_u[i];
+            part_x[i] = -part_x[i];
+        }
+    }
+        
+
+    // Y-DIRECTION: BC particles
+    if (part_y[i] > grd->Ly){
+        if (param->PERIODICY==true){ // PERIODIC
+            part_y[i] = part_y[i] - grd->Ly;
+        } else { // REFLECTING BC
+            part_v[i] = -part_v[i];
+            part_y[i] = 2*grd->Ly - part_y[i];
+        }
+    }
+                                                                
+    if (part_y[i] < 0){
+        if (param->PERIODICY==true){ // PERIODIC
+            part_y[i] = part_y[i] + grd->Ly;
+        } else { // REFLECTING BC
+            part_v[i] = -part_v[i];
+            part_y[i] = -part_y[i];
+        }
+    }
+                                                                
+    // Z-DIRECTION: BC particles
+    if (part_z[i] > grd->Lz){
+        if (param->PERIODICZ==true){ // PERIODIC
+            part_z[i] = part_z[i] - grd->Lz;
+        } else { // REFLECTING BC
+            part_w[i] = -part_w[i];
+            part_z[i] = 2*grd->Lz - part_z[i];
+        }
+    }
+                                                                
+    if (part_z[i] < 0){
+        if (param->PERIODICZ==true){ // PERIODIC
+            part_z[i] = part_z[i] + grd->Lz;
+        } else { // REFLECTING BC
+            part_w[i] = -part_w[i];
+            part_z[i] = -part_z[i];
+        }
+    }
+}
+
+/** CPU serial function to interpolate for a single particle during one subcycle. */
+__host__ void h_interp_particle(register long long i, struct grid grd,
+                                particles_pointers part, ids_pointers ids, grd_pointers grd_p)
+{
+    // arrays needed for interpolation
+    FPpart weight[2][2][2];
+    FPpart temp[2][2][2];
+    FPpart xi[2], eta[2], zeta[2];
+    
+    // index of the cell
+    int ix, iy, iz;
+
+    // determine cell: can we change to int()? is it faster?
+    ix = 2 + int (floor((part.x[i] - grd.xStart) * grd.invdx));
+    iy = 2 + int (floor((part.y[i] - grd.yStart) * grd.invdy));
+    iz = 2 + int (floor((part.z[i] - grd.zStart) * grd.invdz));
+
+    // distances from node
+    xi[0]   = part.x[i] - grd_p.XN_flat[get_idx(ix-1, iy, iz, grd.nyn, grd.nzn)];
+    eta[0]  = part.y[i] - grd_p.YN_flat[get_idx(ix, iy-1, iz, grd.nyn, grd.nzn)];
+    zeta[0] = part.z[i] - grd_p.ZN_flat[get_idx(ix, iy, iz-1, grd.nyn, grd.nzn)];
+    xi[1]   = grd_p.XN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.x[i];
+    eta[1]  = grd_p.YN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.y[i];
+    zeta[1] = grd_p.ZN_flat[get_idx(ix, iy, iz, grd.nyn, grd.nzn)] - part.z[i];
+
+    // calculate the weights for different nodes
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                weight[ii][jj][kk] = part.q[i] * xi[ii] * eta[jj] * zeta[kk] * grd.invVOL;
+
+    //////////////////////////
+    // add charge density
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.rhon_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    ////////////////////////////
+    // add current density - Jx
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.u[i] * weight[ii][jj][kk];
+
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.Jx_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    ////////////////////////////
+    // add current density - Jy
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.v[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.Jy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+
+    ////////////////////////////
+    // add current density - Jz
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.w[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.Jz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    ////////////////////////////
+    // add pressure pxx
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.u[i] * part.u[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pxx_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    ////////////////////////////
+    // add pressure pxy
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.u[i] * part.v[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pxy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+
+    /////////////////////////////
+    // add pressure pxz
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.u[i] * part.w[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pxz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    /////////////////////////////
+    // add pressure pyy
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.v[i] * part.v[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pyy_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    /////////////////////////////
+    // add pressure pyz
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.v[i] * part.w[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pyz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+
+    /////////////////////////////
+    // add pressure pzz
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                temp[ii][jj][kk] = part.w[i] * part.w[i] * weight[ii][jj][kk];
+    for (int ii = 0; ii < 2; ii++)
+        for (int jj = 0; jj < 2; jj++)
+            for (int kk = 0; kk < 2; kk++)
+                ids.pzz_flat[get_idx(ix-ii, iy-jj, iz-kk, grd.nyn, grd.nzn)] += weight[ii][jj][kk] * grd.invVOL;
+
+}
+
+/** Interpolation Particle --> Grid: This is for species */
+// CPU Version
+void h_interpP2G(struct particles* part, struct interpDensSpecies* ids, struct grid* grd)
+{
+    // Create argument structs
+    particles_pointers p_p {
+        part->x, part->y, part->z,
+        part->u, part->v, part->w, part->q
+    };
+    ids_pointers i_p {
+        ids->rhon_flat, ids->rhoc_flat,
+        ids->Jx_flat, ids->Jy_flat, ids->Jz_flat,
+        ids->pxx_flat, ids->pxy_flat, ids->pxz_flat,
+        ids->pyy_flat, ids->pyz_flat, ids->pzz_flat
+    };
+    grd_pointers g_p {
+        grd->XN_flat, grd->YN_flat, grd->ZN_flat
+    };
+    for (register long long i = 0; i < part->nop; i++) {
+        h_interp_particle(i, *grd, p_p, i_p, g_p);
+    }
+}
+

--- a/sputniPIC-master/src/Particles.cu
+++ b/sputniPIC-master/src/Particles.cu
@@ -463,14 +463,14 @@ int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, st
                       << " - batch_start: " << batch_start << ", batch_end: " << batch_end
                       << ", batch_size: " << batch_size << std::endl; */
 
-            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, "cpu_to_gpu",
+            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, CPU_TO_GPU,
                               batch_start, batch_end);
 
             g_move_particle<<<(batch_size+TPB-1)/TPB, TPB>>>(batch_size, part->n_sub_cycles, part->NiterMover, *grd,
                                                                   *param, dt_inf, p_info, f_pointers, g_pointers);
             cudaDeviceSynchronize();
 
-            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, "gpu_to_cpu",
+            copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, GPU_TO_CPU,
                               batch_start, batch_end);
 
             std::cout << "====== In [mover_PC]: batch " << (iter + 1) << " of " << n_iterations << ": done." << std::endl;
@@ -479,7 +479,7 @@ int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, st
 
     // all the particles at once
     else {
-        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, "cpu_to_gpu");
+        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, CPU_TO_GPU);
 
         // h_move_particle(i, part->NiterMover, grd, param, dt_inf, p_info, f_pointers, g_pointers)
         // Launch the kernel
@@ -487,7 +487,7 @@ int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, st
                 *param, dt_inf, p_info, f_pointers, g_pointers);
         cudaDeviceSynchronize();
 
-        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, "gpu_to_cpu");
+        copy_mover_arrays(part, field, grd, p_info, f_pointers, g_pointers, grdSize, field_size, GPU_TO_CPU);
     }
     return(0); // exit successfully
 }
@@ -843,7 +843,7 @@ void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct gri
                       << ", batch_size: " << batch_size << std::endl; */
 
             // copy batch to GPU
-            copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, "cpu_to_gpu",
+            copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, CPU_TO_GPU,
                                batch_start, batch_end);
 
             // launch the kernel to perform on the batch
@@ -851,7 +851,7 @@ void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct gri
             cudaDeviceSynchronize();
 
             // copy batch from GPU back to CPU
-            copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, "gpu_to_cpu",
+            copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, GPU_TO_CPU,
                                batch_start, batch_end);
 
             std::cout << "====== In [interpP2G]: batch " << (iter + 1) << " of " << n_iterations << ": done." << std::endl;
@@ -860,12 +860,12 @@ void interpP2G(struct particles* part, struct interpDensSpecies* ids, struct gri
 
     // all the particles at once
     else {
-        copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, "cpu_to_gpu");
+        copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, CPU_TO_GPU);
 
         // Launch interpolation kernel
         g_interp_particle<<<(part->nop+TPB-1)/TPB, TPB>>>(part->nop, *grd, p_p, i_p, g_p);
         cudaDeviceSynchronize();
 
-        copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, "gpu_to_cpu");
+        copy_interp_arrays(part, ids, grd, p_p, i_p, g_p, grdSize, rhocSize, GPU_TO_CPU);
     }
 }

--- a/sputniPIC-master/src/Particles.cu
+++ b/sputniPIC-master/src/Particles.cu
@@ -95,7 +95,7 @@ void particle_deallocate(struct particles* part)
 /** CPU serial function to move a single particle during one subcycle. */
 __host__ void h_move_particle(int i, int part_NiterMover, struct grid* grd,
                               struct parameters* param, const dt_info dt_inf,
-                              particle_info p_info, field_pointers f_pointers, grd_pointers g_pointers) {
+                              particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers) {
     // extracting the particle variables out of the auxiliary struct
     FPpart* part_x = p_info.x;
     FPpart* part_y = p_info.y;
@@ -262,7 +262,7 @@ __host__ void h_move_particle(int i, int part_NiterMover, struct grid* grd,
 /** GPU kernel to move a single particle */
 __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, struct grid grd,
                                 struct parameters param, const dt_info dt_inf,
-                                particle_info p_info, field_pointers f_pointers, grd_pointers g_pointers) {
+                                particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers) {
     // getting thread ID
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i > nop) return;
@@ -440,7 +440,7 @@ __global__ void g_move_particle(int nop, int n_sub_cycles, int part_NiterMover, 
 
 /** particle mover */
 int mover_PC(struct particles* part, struct EMfield* field, struct grid* grd, struct parameters* param,
-             particle_info p_info, field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size) {
+             particles_pointers p_info, field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size) {
     // print species and subcycling
     std::cout << std::endl << "***  In [mover_PC]: MOVER with SUBCYCLYING "<< param->n_sub_cycles
               << " - species " << part->species_ID << " ***" << std::endl;

--- a/sputniPIC-master/src/helper.cpp
+++ b/sputniPIC-master/src/helper.cpp
@@ -279,14 +279,13 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
 
 
 void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_size,
-                               field_pointers* f_pointers, grd_pointers* g_pointers) {
+                               field_pointers* f_pointers) {
     /** This function allocates the GPU memory needed for the kernel in the mover_PC function. If the number of
      * particles is more than the maximum defined, it only allocates the maximum number of particles already defined,
      * and then operations are done in batches of particles. */
 
     // Declare GPU copies of arrays for mover_PC
     FPfield* f_pointer_copies[6];
-    FPfield* g_pointer_copies[3];
 
     long num_gpu_particles = part->npmax;
     if (part->npmax > MAX_GPU_PARTICLES) {
@@ -300,9 +299,6 @@ void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_si
     {
         for (int i = 0; i < 6; i++)
             cudaMalloc(&f_pointer_copies[i], field_size * sizeof(FPfield));
-
-        for (int i = 0; i < 3; i++)
-            cudaMalloc(&g_pointer_copies[i], grdSize * sizeof(FPfield));
     }
 
     // Put GPU array pointers into structs for mover_PC
@@ -312,10 +308,6 @@ void allocate_mover_gpu_memory(struct particles* part, int grdSize, int field_si
     f_pointers->Bxn_flat = f_pointer_copies[3];
     f_pointers->Byn_flat = f_pointer_copies[4];
     f_pointers->Bzn_flat = f_pointer_copies[5];
-
-    g_pointers->XN_flat = g_pointer_copies[0];
-    g_pointers->YN_flat = g_pointer_copies[1];
-    g_pointers->ZN_flat = g_pointer_copies[2];
 }
 
 
@@ -444,7 +436,7 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
 
 
 void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p,
-                     field_pointers* f_pointers, grd_pointers* g_pointers) {
+                     field_pointers* f_pointers) {
     /** This function frees all the memory allocated on the GPU for both kernels. */
 
     cudaFree(p_p->x);
@@ -481,11 +473,6 @@ void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g
     cudaFree(f_pointers->Byn_flat);
     cudaFree(f_pointers->Bzn_flat);
     cudaFree(f_pointers);
-
-    cudaFree(g_pointers->XN_flat);
-    cudaFree(g_pointers->YN_flat);
-    cudaFree(g_pointers->ZN_flat);
-    cudaFree(g_pointers);
 
     std::cout << "In [free_gpu_memory]: all GPU memory freed.." << std::endl;
 }

--- a/sputniPIC-master/src/helper.cpp
+++ b/sputniPIC-master/src/helper.cpp
@@ -5,87 +5,6 @@ void print(std::string str) {
     std::cout << str << std::endl;
 }
 
-
-void allocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
-                    FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                    FPpart*& batch_q, long batch_size, PICMode mode) 
-{
-    /** This function allocates auxiliary batch variables that contain the data of a batch of particles, used to
-     * transfer batch data between CPU and GPU.
-     * NOTE: depending on the 'mode' variable, batch_q will be ignored (if mode is "mover_PC") */
-
-    batch_x = (FPpart*) malloc(batch_size * sizeof(FPpart));
-    batch_y = (FPpart*) malloc(batch_size * sizeof(FPpart));
-    batch_z = (FPpart*) malloc(batch_size * sizeof(FPpart));
-    batch_u = (FPpart*) malloc(batch_size * sizeof(FPpart));
-    batch_v = (FPpart*) malloc(batch_size * sizeof(FPpart));
-    batch_w = (FPpart*) malloc(batch_size * sizeof(FPpart));
-
-    if (mode == INTERP2G)  // batch_q only used for interp2G, otherwise is ignored
-        batch_q = (FPpart*) malloc(batch_size * sizeof(FPpart));
-}
-
-
-void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
-                      FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                      FPpart*& batch_q, PICMode mode) 
-{
-    /** Since the batch variables are temporary, they are immediately deallocated once the data is copied to the GPU
-     * or copied to the original particles variable
-     * NOTE: depending on the 'mode' variable, batch_q will be ignored (if mode is "mover_PC") */
-
-    free(batch_x);
-    free(batch_y);
-    free(batch_z);
-    free(batch_u);
-    free(batch_v);
-    free(batch_w);
-
-    if (mode == INTERP2G)
-        free(batch_q);
-}
-
-
-void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& batch_u, FPpart*& batch_v,
-                FPpart*& batch_w, FPpart*& batch_q, FPpart*& part_x, FPpart*& part_y, FPpart*& part_z,
-                FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q, long from, long to,
-                PICMode mode, PICMode direction) 
-{
-
-    /** This function copies the data of a batch either from particles to batch variables (to be copied to GPU then)
-     * or from the batch variables (which contain the kernel results on the batch) back to the particles
-     * NOTE: depending on the 'mode' variable, batch_q will be ignored (if mode is "mover_PC") */
-
-    for (long i = from; i < to; i++) {  // could it be more efficient?
-        // iter * MAX_GPU_PARTICLES ==> 0, iter * MAX_GPU_PARTICLES + 1 ==> 1, iter * MAX_GPU_PARTICLES + 2 ==> 2
-        long relative_i = i % MAX_GPU_PARTICLES;  // preventing segmentation fault, relative index in the batch
-
-        if (direction == PARTICLE_TO_BATCH) {
-            batch_x[relative_i] = part_x[i];
-            batch_y[relative_i] = part_y[i];
-            batch_z[relative_i] = part_z[i];
-            batch_u[relative_i] = part_u[i];
-            batch_v[relative_i] = part_v[i];
-            batch_w[relative_i] = part_w[i];
-
-            if (mode == INTERP2G)  // part_q only for inter2G, otherwise ignored
-                batch_q[relative_i] = part_q[i];
-        }
-
-        else {  // direction == "batch_to_particle"
-            part_x[i] = batch_x[relative_i];
-            part_y[i] = batch_y[relative_i];
-            part_z[i] = batch_z[relative_i];
-            part_u[i] = batch_u[relative_i];
-            part_v[i] = batch_v[relative_i];
-            part_w[i] = batch_w[relative_i];
-
-            if (mode == INTERP2G)  // part_q only for inter2G, otherwise ignored
-                 part_q[i] = batch_q[relative_i];
-        }
-    }
-}
-
 /** 
  * This function allocates the GPU memory needed for the kernels in the mover_pc and interp2G functions. If the number of
  * particles is more than the maximum defined, it only allocates the maximum number of particles already defined,
@@ -101,19 +20,12 @@ void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize,
     FPfield* grd_copies[3];
     FPfield* field_copies[6];
 
-    long num_gpu_particles = part->npmax;
-    if (part->npmax > MAX_GPU_PARTICLES) {
-        num_gpu_particles = MAX_GPU_PARTICLES;
-        std::cout << "In [allocate_interp_gpu_memory]: part->nop is greater than MAX_GPU_PARTICLES. "
-                     "Allocating only up to MAX_GPU_PARTICLES particles..." << std::endl;
-    }
-
-    // Allocate GPU arrays for interpP2G
+    // Allocate GPU arrays 
     {
-        cudaMalloc(&part_copy_q, num_gpu_particles * sizeof(FPinterp));
+        cudaMalloc(&part_copy_q, part->npmax * sizeof(FPinterp));
 
         for (int i = 0; i < 6; ++i)
-            cudaMalloc(&part_copies[i], num_gpu_particles * sizeof(FPpart));
+            cudaMalloc(&part_copies[i], part->npmax * sizeof(FPpart));
 
         for (int i = 0; i < 11; ++i)
             cudaMalloc(&ids_copies[i], grdSize * sizeof(FPinterp));
@@ -125,7 +37,7 @@ void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize,
             cudaMalloc(&field_copies[i], fieldSize * sizeof(FPfield));
     }
 
-    // Put GPU array pointers into structs for interpP2G
+    // Put GPU array pointers into structs
     p_p->x = part_copies[0];
     p_p->y = part_copies[1];
     p_p->z = part_copies[2];
@@ -158,11 +70,14 @@ void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize,
     f_p->Bzn_flat = field_copies[5];
 }
 
-
+/** 
+ * This function copies from CPU to GPU the data needed for running the kernel in the interp2G function. 
+ */
 void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, struct grid* grd,
                         particles_pointers p_p, ids_pointers i_p, grd_pointers g_p, 
                         int grdSize, int rhocSize, 
-                        PICMode mode, long from, long to, bool verbose) {
+                        PICMode mode, long from, long to, bool verbose) 
+{
     /** This function copies from CPU to GPU the data needed for running the kernel in the interp2G function.
      * For more info see the copy_mover_arrays function. */
 
@@ -172,43 +87,20 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
         batch_size = to - from;
         if (verbose) std::cout << "In [copy_interp_arrays]: copying with batch size of " << batch_size << std::endl;
     }
-
-    // prepare mini-batch structures if we mini-batching should be performed
-    FPpart* batch_x; FPpart* batch_y; FPpart* batch_z; FPpart* batch_u; FPpart* batch_v; FPpart* batch_w; FPpart* batch_q;
-    if (batch_size != -1) {  // mini-batch copying
-        allocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                       batch_q, batch_size, INTERP2G);
-        if (verbose) std::cout << "In [copy_interp_arrays]: batch variables created..." << std::endl;
-    }
     
     // Copy CPU arrays to GPU
     if (mode == CPU_TO_GPU) { 
-    
         // mini-batching
-        if (batch_size != -1)
-        {
-            // copy from particles to batch variables
-            batch_copy(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w, batch_q,
-                       part->x, part->y, part->z, part->u, part->v, part->w, part->q,
-                          from, to, INTERP2G, PARTICLE_TO_BATCH);
-            if (verbose) std::cout << "In [copy_interp_arrays]: copy from part to batch done." << std::endl;
-
+        if (batch_size != -1) {
             // copy from batch variables to GPU
-            cudaMemcpy(p_p.x, batch_x, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.y, batch_y, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.z, batch_z, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.u, batch_u, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.v, batch_v, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.w, batch_w, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.q, batch_q, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-
+            cudaMemcpy(&p_p.x[from], &part->x[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.y[from], &part->y[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.z[from], &part->z[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.u[from], &part->u[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.v[from], &part->v[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.w[from], &part->w[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.q[from], &part->q[from], batch_size * sizeof(FPinterp), cudaMemcpyHostToDevice);
             if (verbose) std::cout << "In [copy_interp_arrays]: copy to GPU: done." << std::endl;
-
-
-            // deallocate the memory once the data is copied to the GPU memory
-            deallocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                             batch_q, INTERP2G);
-            if (verbose) std::cout << "In [copy_interp_arrays]: batch variables freed..." << std::endl;
         }
         // copy all the particles at once
         else {
@@ -218,10 +110,8 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
             cudaMemcpy(p_p.u, part->u, part->npmax*sizeof(FPpart), cudaMemcpyHostToDevice);
             cudaMemcpy(p_p.v, part->v, part->npmax*sizeof(FPpart), cudaMemcpyHostToDevice);
             cudaMemcpy(p_p.w, part->w, part->npmax*sizeof(FPpart), cudaMemcpyHostToDevice);
-
             cudaMemcpy(p_p.q, part->q, part->npmax*sizeof(FPinterp), cudaMemcpyHostToDevice);
         }
-
         cudaMemcpy(i_p.rhon_flat, ids->rhon_flat, grdSize*sizeof(FPinterp), cudaMemcpyHostToDevice);
         cudaMemcpy(i_p.rhoc_flat, ids->rhoc_flat, rhocSize*sizeof(FPinterp), cudaMemcpyHostToDevice);
         cudaMemcpy(i_p.Jx_flat, ids->Jx_flat, grdSize*sizeof(FPinterp), cudaMemcpyHostToDevice);
@@ -240,13 +130,6 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
     } 
     // Copy GPU arrays back to CPU - only ids needs to be copied.
     else { 
-        // mini-batching
-        if (batch_size != -1) {
-            // deallocate the memory once the data is copied to the original particles
-            deallocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                             batch_q, INTERP2G);
-        }
-
         cudaMemcpy(ids->rhon_flat, i_p.rhon_flat, grdSize*sizeof(FPinterp), cudaMemcpyDeviceToHost);
         cudaMemcpy(ids->rhoc_flat, i_p.rhoc_flat, rhocSize*sizeof(FPinterp), cudaMemcpyDeviceToHost);
         cudaMemcpy(ids->Jx_flat, i_p.Jx_flat, grdSize*sizeof(FPinterp), cudaMemcpyDeviceToHost);
@@ -261,15 +144,16 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
     }
 }
 
+/** 
+ * This function copies from CPU to GPU the data needed for running the kernel in the mover_pc function
+ * long 'from' and long 'to' (if specified) determine which elements of the particle arrays should be copied to GPU.
+ * If not specified (default), all the particles will be copied.
+ * NOTE: to is exclusive => mini-batch size is (to - from) 
+ */
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, 
                        particles_pointers p_p, field_pointers f_p, grd_pointers g_p, 
                        int grdSize, int field_size,
                        PICMode mode, long from, long to, bool verbose) {
-    /** This function copies from CPU to GPU the data needed for running the kernel in the interp2G function
-     * long 'from' and long 'to' (if specified) determine which elements of the particle arrays should be copied to GPU.
-     * If not specified (default), all the particles will be copied.
-     * NOTE: to is exclusive => mini-batch size is (to - from) */
-
     // if batch_size is not -1, it means that mini-batching should be done
     long batch_size = -1;
     if (from != -1 && to != -1) {  // determine size of mini-batch, if from and to are specified
@@ -277,42 +161,18 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
         if (verbose) std::cout << "In [copy_mover_arrays]: copying with batch size of " << batch_size << std::endl;
     }
 
-    // prepare mini-batch structures if we mini-batching should be performed
-    FPpart* batch_x; FPpart* batch_y; FPpart* batch_z; FPpart* batch_u; FPpart* batch_v; FPpart* batch_w; FPpart* batch_q;
-    if (batch_size != -1) {  // mini-batch copying
-        allocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                       batch_q, batch_size, MOVER_PC);  // by specifying "mover_PC", batch_q will be ignored
-
-        if (verbose) std::cout << "In [copy_mover_arrays]: batch variables created..." << std::endl;
-    }
-
     // Copy CPU arrays to GPU
     if (mode == CPU_TO_GPU) {
-        // copy the mini-batch
+        // copy the particles in the mini-batch
         if (batch_size != -1) {
-            // copy from particles to batch variables
-            batch_copy(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w, batch_q,
-                       part->x, part->y, part->z, part->u, part->v, part->w, part->q,
-                       from, to, MOVER_PC, PARTICLE_TO_BATCH);
-
-            if (verbose) std::cout << "In [copy_mover_arrays]: copy from part to batch done." << std::endl;
-
-            // copy from batch variables to GPU
-            cudaMemcpy(p_p.x, batch_x, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.y, batch_y, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.z, batch_z, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.u, batch_u, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.v, batch_v, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-            cudaMemcpy(p_p.w, batch_w, batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
-
-            if (verbose) std::cout << "In [copy_mover_arrays]: copy to GPU done..." << std::endl;
-
-            // deallocate the memory once the data is copied to the GPU memory
-            deallocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                             batch_q, MOVER_PC);
-            if (verbose) std::cout << "In [copy_mover_arrays]: batch variables freed..." << std::endl;
+            cudaMemcpy(&p_p.x[from], &part->x[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.y[from], &part->y[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.z[from], &part->z[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.u[from], &part->u[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.v[from], &part->v[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            cudaMemcpy(&p_p.w[from], &part->w[from], batch_size * sizeof(FPpart), cudaMemcpyHostToDevice);
+            if (verbose) std::cout << "In [copy_mover_arrays]: batch copy to GPU done..." << std::endl;
         }
-
         // copy all the particles at once
         else {
             cudaMemcpy(p_p.x, part->x, part->npmax * sizeof(FPpart), cudaMemcpyHostToDevice);
@@ -336,30 +196,18 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
         cudaMemcpy(g_p.YN_flat, grd->YN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
         cudaMemcpy(g_p.ZN_flat, grd->ZN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
     }
-
     // Copy GPU arrays back to CPU - only particles need to be copied
     else {
-        // copy the mini-batch
+        // copy the particles in the mini-batch
         if (batch_size != -1) {
-            cudaMemcpy(batch_x, p_p.x, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-            cudaMemcpy(batch_y, p_p.y, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-            cudaMemcpy(batch_z, p_p.z, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-            cudaMemcpy(batch_u, p_p.u, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-            cudaMemcpy(batch_v, p_p.v, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-            cudaMemcpy(batch_w, p_p.w, batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
-
+            cudaMemcpy(&part->x[from], &p_p.x[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
+            cudaMemcpy(&part->y[from], &p_p.y[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
+            cudaMemcpy(&part->z[from], &p_p.z[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
+            cudaMemcpy(&part->u[from], &p_p.u[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
+            cudaMemcpy(&part->v[from], &p_p.v[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
+            cudaMemcpy(&part->w[from], &p_p.w[from], batch_size * sizeof(FPpart), cudaMemcpyDeviceToHost);
             if (verbose) std::cout << "In [copy_mover_arrays]: copy back to CPU done..." << std::endl;
-
-            batch_copy(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w, batch_q,
-                       part->x, part->y, part->z, part->u, part->v, part->w, part->q,
-                          from, to, MOVER_PC, BATCH_TO_PARTICLE);
-
-            // deallocate the memory once the data is copied to the original particles
-            deallocate_batch(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w,
-                             batch_q, MOVER_PC);
-            if (verbose) std::cout << "In [copy_mover_arrays]: batch variables freed..." << std::endl;
         }
-
         // copy all particles at once
         else {
             cudaMemcpy(part->x, p_p.x, part->npmax * sizeof(FPpart), cudaMemcpyDeviceToHost);

--- a/sputniPIC-master/src/helper.cpp
+++ b/sputniPIC-master/src/helper.cpp
@@ -424,7 +424,6 @@ void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g
     cudaFree(p_p->v);
     cudaFree(p_p->w);
     cudaFree(p_p->q);
-    cudaFree(p_p);  // freeing the top-level pointer
 
     cudaFree(i_p->rhon_flat);
     cudaFree(i_p->rhoc_flat);
@@ -437,12 +436,10 @@ void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g
     cudaFree(i_p->pyy_flat);
     cudaFree(i_p->pyz_flat);
     cudaFree(i_p->pzz_flat);
-    cudaFree(i_p);
 
     cudaFree(g_p->XN_flat);
     cudaFree(g_p->YN_flat);
     cudaFree(g_p->ZN_flat);
-    cudaFree(g_p);
 
     cudaFree(f_pointers->Ex_flat);
     cudaFree(f_pointers->Ey_flat);
@@ -450,7 +447,6 @@ void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g
     cudaFree(f_pointers->Bxn_flat);
     cudaFree(f_pointers->Byn_flat);
     cudaFree(f_pointers->Bzn_flat);
-    cudaFree(f_pointers);
 
     std::cout << "In [free_gpu_memory]: all GPU memory freed.." << std::endl;
 }

--- a/sputniPIC-master/src/helper.cpp
+++ b/sputniPIC-master/src/helper.cpp
@@ -8,7 +8,8 @@ void print(std::string str) {
 
 void allocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
                     FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                    FPpart*& batch_q, long batch_size, PICMode mode) {
+                    FPpart*& batch_q, long batch_size, PICMode mode) 
+{
     /** This function allocates auxiliary batch variables that contain the data of a batch of particles, used to
      * transfer batch data between CPU and GPU.
      * NOTE: depending on the 'mode' variable, batch_q will be ignored (if mode is "mover_PC") */
@@ -27,7 +28,8 @@ void allocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
 
 void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
                       FPpart*& batch_u, FPpart*& batch_v, FPpart*& batch_w,
-                      FPpart*& batch_q, PICMode mode) {
+                      FPpart*& batch_q, PICMode mode) 
+{
     /** Since the batch variables are temporary, they are immediately deallocated once the data is copied to the GPU
      * or copied to the original particles variable
      * NOTE: depending on the 'mode' variable, batch_q will be ignored (if mode is "mover_PC") */
@@ -47,7 +49,8 @@ void deallocate_batch(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z,
 void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& batch_u, FPpart*& batch_v,
                 FPpart*& batch_w, FPpart*& batch_q, FPpart*& part_x, FPpart*& part_y, FPpart*& part_z,
                 FPpart*& part_u, FPpart*& part_v, FPpart*& part_w, FPpart*& part_q, long from, long to,
-                PICMode mode, PICMode direction) {
+                PICMode mode, PICMode direction) 
+{
 
     /** This function copies the data of a batch either from particles to batch variables (to be copied to GPU then)
      * or from the batch variables (which contain the kernel results on the batch) back to the particles
@@ -90,7 +93,8 @@ void batch_copy(FPpart*& batch_x, FPpart*& batch_y, FPpart*& batch_z, FPpart*& b
  */
 void allocate_gpu_memory(struct particles* part, int grdSize, int fieldSize, 
                                 particles_pointers* p_p, ids_pointers* i_p,
-                                grd_pointers* g_p, field_pointers* f_p) {
+                                grd_pointers* g_p, field_pointers* f_p) 
+{
     
     FPpart* part_copies[6]; FPinterp* part_copy_q;
     FPinterp* ids_copies[11];
@@ -176,12 +180,13 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
                        batch_q, batch_size, INTERP2G);
         if (verbose) std::cout << "In [copy_interp_arrays]: batch variables created..." << std::endl;
     }
-
-
+    
     // Copy CPU arrays to GPU
-    if (mode == CPU_TO_GPU) {
+    if (mode == CPU_TO_GPU) { 
+    
         // mini-batching
-        if (batch_size != -1){
+        if (batch_size != -1)
+        {
             // copy from particles to batch variables
             batch_copy(batch_x, batch_y, batch_z, batch_u, batch_v, batch_w, batch_q,
                        part->x, part->y, part->z, part->u, part->v, part->w, part->q,

--- a/sputniPIC-master/src/helper.cpp
+++ b/sputniPIC-master/src/helper.cpp
@@ -291,7 +291,7 @@ void copy_interp_arrays(struct particles* part, struct interpDensSpecies* ids, s
 }
 
 void copy_mover_arrays(struct particles* part, struct EMfield* field, struct grid* grd, particles_pointers p_info,
-                       field_pointers f_pointers, grd_pointers g_pointers, int grdSize, int field_size,
+                       field_pointers f_p, grd_pointers g_p, int grdSize, int field_size,
                        PICMode mode, long from, long to, bool verbose) {
     /** This function copies from CPU to GPU the data needed for running the kernel in the interp2G function
      * long 'from' and long 'to' (if specified) determine which elements of the particle arrays should be copied to GPU.
@@ -352,17 +352,17 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
         }
 
         // copy field variables
-        cudaMemcpy(f_pointers.Ex_flat, field->Ex_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(f_pointers.Ey_flat, field->Ey_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(f_pointers.Ez_flat, field->Ez_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(f_pointers.Bxn_flat, field->Bxn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(f_pointers.Byn_flat, field->Byn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(f_pointers.Bzn_flat, field->Bzn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Ex_flat, field->Ex_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Ey_flat, field->Ey_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Ez_flat, field->Ez_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Bxn_flat, field->Bxn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Byn_flat, field->Byn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(f_p.Bzn_flat, field->Bzn_flat, field_size * sizeof(FPfield), cudaMemcpyHostToDevice);
 
         // copy grid variables
-        cudaMemcpy(g_pointers.XN_flat, grd->XN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(g_pointers.YN_flat, grd->YN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
-        cudaMemcpy(g_pointers.ZN_flat, grd->ZN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(g_p.XN_flat, grd->XN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(g_p.YN_flat, grd->YN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
+        cudaMemcpy(g_p.ZN_flat, grd->ZN_flat, grdSize * sizeof(FPfield), cudaMemcpyHostToDevice);
     }
 
     // Copy GPU arrays back to CPU
@@ -399,24 +399,24 @@ void copy_mover_arrays(struct particles* part, struct EMfield* field, struct gri
         }
 
         // copy field variables
-        cudaMemcpy(field->Ex_flat, f_pointers.Ex_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(field->Ey_flat, f_pointers.Ey_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(field->Ez_flat, f_pointers.Ez_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(field->Bxn_flat, f_pointers.Bxn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(field->Byn_flat, f_pointers.Byn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(field->Bzn_flat, f_pointers.Bzn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Ex_flat, f_p.Ex_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Ey_flat, f_p.Ey_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Ez_flat, f_p.Ez_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Bxn_flat, f_p.Bxn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Byn_flat, f_p.Byn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(field->Bzn_flat, f_p.Bzn_flat, field_size * sizeof(FPfield), cudaMemcpyDeviceToHost);
 
         // copy grid variables
-        cudaMemcpy(grd->XN_flat, g_pointers.XN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(grd->YN_flat, g_pointers.YN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
-        cudaMemcpy(grd->ZN_flat, g_pointers.ZN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(grd->XN_flat, g_p.XN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(grd->YN_flat, g_p.YN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
+        cudaMemcpy(grd->ZN_flat, g_p.ZN_flat, grdSize * sizeof(FPfield), cudaMemcpyDeviceToHost);
     }
 }
 
 /** 
  * This function frees all the memory allocated on the GPU for both kernels.
  */
-void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p, field_pointers* f_pointers) {
+void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g_p, field_pointers* f_p) {
     cudaFree(p_p->x);
     cudaFree(p_p->y);
     cudaFree(p_p->z);
@@ -441,12 +441,12 @@ void free_gpu_memory(particles_pointers* p_p, ids_pointers* i_p, grd_pointers* g
     cudaFree(g_p->YN_flat);
     cudaFree(g_p->ZN_flat);
 
-    cudaFree(f_pointers->Ex_flat);
-    cudaFree(f_pointers->Ey_flat);
-    cudaFree(f_pointers->Ez_flat);
-    cudaFree(f_pointers->Bxn_flat);
-    cudaFree(f_pointers->Byn_flat);
-    cudaFree(f_pointers->Bzn_flat);
+    cudaFree(f_p->Ex_flat);
+    cudaFree(f_p->Ey_flat);
+    cudaFree(f_p->Ez_flat);
+    cudaFree(f_p->Bxn_flat);
+    cudaFree(f_p->Byn_flat);
+    cudaFree(f_p->Bzn_flat);
 
     std::cout << "In [free_gpu_memory]: all GPU memory freed.." << std::endl;
 }

--- a/sputniPIC-master/src/sputniPIC.cpp
+++ b/sputniPIC-master/src/sputniPIC.cpp
@@ -84,8 +84,8 @@ int main(int argc, char **argv){
     allocate_interp_gpu_memory(part, grdSize, &p_p, &i_p, &g_p);  // Allocates maximum MAX_GPU_PARTICLES particles
 
     int field_size = grd.nxn * grd.nyn * grd.nzn;
-    field_pointers f_pointers; grd_pointers g_pointers;  // on the GPU memory
-    allocate_mover_gpu_memory(part, grdSize, field_size, &f_pointers, &g_pointers);
+    field_pointers f_pointers; // on the GPU memory
+    allocate_mover_gpu_memory(part, grdSize, field_size, &f_pointers);
     std::cout << "In [main]: All GPU memory allocation: done" << std::endl;
 
 
@@ -110,7 +110,7 @@ int main(int argc, char **argv){
         iMover = cpuSecond(); // start timer for mover
         for (int is=0; is < param.ns; is++)
             // mover_PC(&part[is],&field,&grd,&param);
-            mover_PC(&part[is], &field, &grd, &param, p_p, f_pointers, g_pointers, grdSize, field_size);
+            mover_PC(&part[is], &field, &grd, &param, p_p, f_pointers, g_p, grdSize, field_size);
 
         eMover += (cpuSecond() - iMover); // stop timer for mover
         
@@ -158,7 +158,7 @@ int main(int argc, char **argv){
     // -------------------------------------------------------------- //
     // ------ Additions for GPU version ----------------------------- //
     // Free GPU arrays
-    free_gpu_memory(&p_p, &i_p, &g_p, &f_pointers, &g_pointers);
+    free_gpu_memory(&p_p, &i_p, &g_p, &f_pointers);
 
     // stop timer
     double iElaps = cpuSecond() - iStart;

--- a/sputniPIC-master/src/sputniPIC.cpp
+++ b/sputniPIC-master/src/sputniPIC.cpp
@@ -84,8 +84,8 @@ int main(int argc, char **argv){
     allocate_interp_gpu_memory(part, grdSize, &p_p, &i_p, &g_p);  // Allocates maximum MAX_GPU_PARTICLES particles
 
     int field_size = grd.nxn * grd.nyn * grd.nzn;
-    particle_info p_info; field_pointers f_pointers; grd_pointers g_pointers;  // on the GPU memory
-    allocate_mover_gpu_memory(part, grdSize, field_size, &p_info, &f_pointers, &g_pointers);
+    field_pointers f_pointers; grd_pointers g_pointers;  // on the GPU memory
+    allocate_mover_gpu_memory(part, grdSize, field_size, &f_pointers, &g_pointers);
     std::cout << "In [main]: All GPU memory allocation: done" << std::endl;
 
 
@@ -110,7 +110,7 @@ int main(int argc, char **argv){
         iMover = cpuSecond(); // start timer for mover
         for (int is=0; is < param.ns; is++)
             // mover_PC(&part[is],&field,&grd,&param);
-            mover_PC(&part[is], &field, &grd, &param, p_info, f_pointers, g_pointers, grdSize, field_size);
+            mover_PC(&part[is], &field, &grd, &param, p_p, f_pointers, g_pointers, grdSize, field_size);
 
         eMover += (cpuSecond() - iMover); // stop timer for mover
         
@@ -158,7 +158,7 @@ int main(int argc, char **argv){
     // -------------------------------------------------------------- //
     // ------ Additions for GPU version ----------------------------- //
     // Free GPU arrays
-    free_gpu_memory(&p_p, &i_p, &g_p, &p_info, &f_pointers, &g_pointers);
+    free_gpu_memory(&p_p, &i_p, &g_p, &f_pointers, &g_pointers);
 
     // stop timer
     double iElaps = cpuSecond() - iStart;

--- a/sputniPIC-master/src/sputniPIC.cpp
+++ b/sputniPIC-master/src/sputniPIC.cpp
@@ -80,12 +80,11 @@ int main(int argc, char **argv){
     // Declare GPU copies of arrays for interpP2G
     int grdSize = grd.nxn * grd.nyn * grd.nzn;
     int rhocSize = grd.nxc * grd.nyc * grd.nzc;
-    particles_pointers p_p; ids_pointers i_p; grd_pointers g_p;  // on the GPU memory
-    allocate_interp_gpu_memory(part, grdSize, &p_p, &i_p, &g_p);  // Allocates maximum MAX_GPU_PARTICLES particles
-
     int field_size = grd.nxn * grd.nyn * grd.nzn;
-    field_pointers f_pointers; // on the GPU memory
-    allocate_mover_gpu_memory(part, grdSize, field_size, &f_pointers);
+    particles_pointers p_p; ids_pointers i_p; grd_pointers g_p; field_pointers f_p; // on the GPU memory
+    allocate_gpu_memory(part, grdSize, field_size, &p_p, &i_p, &g_p, &f_p);  // Allocates maximum MAX_GPU_PARTICLES particles
+    
+     // on the GPU memory
     std::cout << "In [main]: All GPU memory allocation: done" << std::endl;
 
 
@@ -110,7 +109,7 @@ int main(int argc, char **argv){
         iMover = cpuSecond(); // start timer for mover
         for (int is=0; is < param.ns; is++)
             // mover_PC(&part[is],&field,&grd,&param);
-            mover_PC(&part[is], &field, &grd, &param, p_p, f_pointers, g_p, grdSize, field_size);
+            mover_PC(&part[is], &field, &grd, &param, p_p, f_p, g_p, grdSize, field_size);
 
         eMover += (cpuSecond() - iMover); // stop timer for mover
         
@@ -158,7 +157,7 @@ int main(int argc, char **argv){
     // -------------------------------------------------------------- //
     // ------ Additions for GPU version ----------------------------- //
     // Free GPU arrays
-    free_gpu_memory(&p_p, &i_p, &g_p, &f_pointers);
+    free_gpu_memory(&p_p, &i_p, &g_p, &f_p);
 
     // stop timer
     double iElaps = cpuSecond() - iStart;


### PR DESCRIPTION
This PR refactors the mini-batching logic to do the following:
- Arrays that are constant are copied only once to GPU
- Arrays that are not modified are not copied back from GPU
- Arrays with results are copied at most once from GPU back to CPU 
- Remove extra arrays (batch structures and arrays that are used by both mover_PC and interpP2G)
